### PR TITLE
Use datadog's pip in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ If you are ready with this, go directly to Step 3: Installing the check.
 
 1. Clone or download from [https://github.com/bithauschile/datadog-ga](https://github.com/bithauschile/datadog-ga)
 2. Install python libraries
-  1. Install pip: `apt-get install python-pip`
-  2. Use pip to install the Google API client for Python: `pip install --upgrade google-api-python-client`
+  1. Use pip to install the Google API client for Python: `/opt/datadog-agent/embedded/pip install --upgrade google-api-python-client`
 3. Install the check:
   - Copy ga.yaml to /etc/dd-agent/conf.d/
   - Copy ga.py to /etc/dd-agent/checks.d/


### PR DESCRIPTION
I had problems installing ga agent because datadog agent uses it's own python, not the system's one. I found that datadog uses python from /opt/datadog-agent/embedded/ directory.
