### PR TITLE
missing config in ga.yaml

### DIFF
--- a/ga.yaml
+++ b/ga.yaml
@@ -16,7 +16,9 @@ init_config:
 #
 #
 # Example
-#
+
+#instances:
+
 #   - profile: ga:12345678
 #     tags:
 #      - env:production


### PR DESCRIPTION
instances was missing from the default ga.yaml.
